### PR TITLE
Fix streamlist file parsing for Windows

### DIFF
--- a/config.c
+++ b/config.c
@@ -94,7 +94,7 @@ sl_add_streamlist_file (SLCD *slconn, const char *streamfile,
     if ((cp = strchr (line, '\r')) != NULL || (cp = strchr (line, '\n')) != NULL)
       *cp = '\0';
 
-    fields = sscanf (line, "%63s %199c", stationid, selectors);
+    fields = sscanf (line, "%63s %199[^\r\n]", stationid, selectors);
 
     /* Skip blank or comment lines */
     if (fields <= 0 || stationid[0] == '#')


### PR DESCRIPTION
On Windows, parsing streamlist.conf returned only one `fields` due to the use of `%c` in `sscanf`, leading to incorrect parsing of stream selectors.
This suggestion replaces `%c` with a scanset to correctly handle line endings and ensure consistent reading across platforms.
Tested on both Windows and Linux.